### PR TITLE
Make the Silver Release Lantern a non-consumable item

### DIFF
--- a/Content/Items/SilverReleaseLantern.cs
+++ b/Content/Items/SilverReleaseLantern.cs
@@ -1,4 +1,4 @@
-﻿using Luminance.Common.Utilities;
+using Luminance.Common.Utilities;
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
@@ -19,6 +19,7 @@ namespace WoTE.Content.Items
             Item.damage = 0;
             Item.DamageType = DamageClass.Default;
             Item.rare = ItemRarityID.Purple;
+            Item.consumable = false;
             Item.noUseGraphic = true;
         }
 


### PR DESCRIPTION
This is very much not a needed change, but I think it could improve the overall user experience.